### PR TITLE
Fix download single track JS error

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,8 +222,7 @@ function downloadPlaylist(playlist,
     .sequence()
     .map(playlistTrack => playlistTrack.track)
     .filter(track => !isTrackDownloaded(track.id, metadata))
-    .flatMap(track => downloadTrack(track, { format, quality, path: targetPath, logger, metadata }))
-    .map(() => saveMetadata(metadata, metadataPath));
+    .flatMap(track => downloadTrack(track, { format, quality, path: targetPath, logger, metadata }));
 }
 
 /**
@@ -241,6 +240,11 @@ function downloadTrack(track,
   let trackName = `${track.artists[0].name} - ${track.name}`;
   info(logger, chalk.bold.blue(leftPad("[Downloading track]", INFO_COLUMN_WIDTH)), trackName);
 
+  let metadataPath = fsPath.join(path, METADATA_FILE);
+  if (!metadata) {
+    metadata = getMetadata(metadataPath);
+  }
+
   if (isTrackDownloaded(track.id, metadata)) {
     warn(logger, `Media is already downloaded`);
     return throughStream();
@@ -248,8 +252,9 @@ function downloadTrack(track,
 
   let downloadFunction = format === 'video' ? downloadYoutubeVideo : downloadYoutubeAudio;
   return downloadFunction(trackName, path, { quality, logger })
-    .map(() => updateMetadata(track, metadata));
-}
+    .map(() => updateMetadata(track, metadata))
+    .map(() => saveMetadata(metadata, metadataPath));
+  }
 
 ////
 // DOWNLOAD


### PR DESCRIPTION
This should fix issue #6 

As a plus, I've noticed that _single file download_ wasn't writing to .downloaded manifest file, so it **always** re-download even if the file was already downloaded. I've fixed that too.

Evidences:
- **No JS error**
![image](https://user-images.githubusercontent.com/2450417/31209575-46a85986-a962-11e7-8923-0469e67d4a54.png)
- **No re-download**
![image](https://user-images.githubusercontent.com/2450417/31209593-62968f50-a962-11e7-915b-0ceb9d7d5eaa.png)
